### PR TITLE
Reduce ISender Implementation Responsibilities

### DIFF
--- a/src/Jasper.AzureServiceBus/AzureServiceBusEndpoint.cs
+++ b/src/Jasper.AzureServiceBus/AzureServiceBusEndpoint.cs
@@ -140,7 +140,7 @@ namespace Jasper.AzureServiceBus
         protected override ISender CreateSender(IMessagingRoot root)
         {
             if (Parent.ConnectionString == null) throw new InvalidOperationException("There is no configured connection string for Azure Service Bus, or it is empty");
-            return new AzureServiceBusSender(this, Parent, root.TransportLogger, root.Cancellation);
+            return new AzureServiceBusSender(this, Parent);
         }
     }
 }

--- a/src/Jasper.AzureServiceBus/Internal/AzureServiceBusSender.cs
+++ b/src/Jasper.AzureServiceBus/Internal/AzureServiceBusSender.cs
@@ -76,7 +76,7 @@ namespace Jasper.AzureServiceBus.Internal
         }
 
 
-        public Task Enqueue(Envelope envelope)
+        public Task Send(Envelope envelope)
         {
             _sending.Post(envelope);
 

--- a/src/Jasper.ConfluentKafka.Tests/end_to_end.cs
+++ b/src/Jasper.ConfluentKafka.Tests/end_to_end.cs
@@ -41,30 +41,31 @@ namespace Jasper.ConfluentKafka.Tests
             public Sender()
             {
                 Endpoints.ConfigureKafka();
-
+                Endpoints.PublishAllMessages().ToKafkaTopic(Topic, ProducerConfig);
             }
 
-            public string QueueName { get; set; }
+            public string Topic = "messages";
         }
 
         public class Receiver : JasperOptions
         {
-            public Receiver(string queueName)
+            public Receiver(string topic)
             {
                 Endpoints.ConfigureKafka();
+                Endpoints.ListenToKafkaTopic(topic, ConsumerConfig).UseForReplies();
             }
         }
 
 
         public class KafkaSendingComplianceTests : SendingCompliance
         {
-            public KafkaSendingComplianceTests() : base($"kafka://topic/messages".ToUri())
+            public KafkaSendingComplianceTests() : base($"kafka://topic/messages".ToUri(), 15.Seconds())
             {
                 var sender = new Sender();
 
                 SenderIs(sender);
 
-                var receiver = new Receiver(sender.QueueName);
+                var receiver = new Receiver(sender.Topic);
 
                 ReceiverIs(receiver);
             }

--- a/src/Jasper.ConfluentKafka.Tests/end_to_end.cs
+++ b/src/Jasper.ConfluentKafka.Tests/end_to_end.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Hosting;
 using Shouldly;
 using TestingSupport;
 using TestingSupport.Compliance;
+using TestingSupport.ErrorHandling;
+using TestMessages;
 using Xunit;
 
 namespace Jasper.ConfluentKafka.Tests
@@ -26,6 +28,11 @@ namespace Jasper.ConfluentKafka.Tests
         {
             BootstrapServers = KafkaServer,
             SecurityProtocol = SecurityProtocol.Ssl
+        };
+        private static ProducerConfig FailureProducerConfig = new ProducerConfig
+        {
+            BootstrapServers = "badaddress",
+            MessageTimeoutMs = 1000
         };
 
         private static ConsumerConfig ConsumerConfig = new ConsumerConfig
@@ -44,6 +51,16 @@ namespace Jasper.ConfluentKafka.Tests
                 Endpoints.ConfigureKafka();
                 Endpoints.PublishAllMessages().ToKafkaTopic(Topic, ProducerConfig);
                 Endpoints.ListenToKafkaTopic(ReplyTopic, ConsumerConfig).UseForReplies();
+            }
+        }
+
+        public class FailureSender : JasperOptions
+        {
+            public const string Topic = "jasper-compliance";
+            public FailureSender()
+            {
+                Endpoints.ConfigureKafka();
+                Endpoints.PublishAllMessages().ToKafkaTopic(Topic, FailureProducerConfig);
             }
         }
 
@@ -69,6 +86,22 @@ namespace Jasper.ConfluentKafka.Tests
                 var receiver = new Receiver(Sender.Topic);
 
                 ReceiverIs(receiver);
+            }
+
+            [Fact]
+            public async Task publish_failures_reported_to_caller()
+            {
+                theSender = null;
+                SenderIs<FailureSender>();
+
+                _ = await theSender.TrackActivity(60.Seconds())
+                    .DoNotAssertOnExceptionsDetected()
+                    .DoNotAssertTimeout()
+                    .ExecuteAndWait(c =>
+                    {
+                        Should.Throw<Exception>(c.Publish(new Message1()));
+                        return Task.CompletedTask;
+                    });
             }
         }
 
@@ -96,7 +129,6 @@ namespace Jasper.ConfluentKafka.Tests
 
             colors.Name.ShouldBe("Red");
         }
-
 
         [Fact]
         public async Task send_multiple_messages_in_order()

--- a/src/Jasper.ConfluentKafka/Exceptions/KafkaSenderException.cs
+++ b/src/Jasper.ConfluentKafka/Exceptions/KafkaSenderException.cs
@@ -1,0 +1,15 @@
+using System;
+using Confluent.Kafka;
+
+namespace Jasper.ConfluentKafka.Exceptions
+{
+    public class KafkaSenderException : ApplicationException
+    {
+        public Error Error { get; }
+
+        public KafkaSenderException(Error error) : base(error.Reason)
+        {
+            Error = error;
+        }
+    }
+}

--- a/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaListener.cs
+++ b/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaListener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
@@ -43,6 +44,8 @@ namespace Jasper.Kafka.Internal
             _consumer.Subscribe(new []{ _endpoint.TopicName });
 
             _consumerTask = ConsumeAsync();
+
+            _logger.ListeningStatusChange(ListeningStatus.Accepting);
         }
 
         private async Task ConsumeAsync()

--- a/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaListener.cs
+++ b/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaListener.cs
@@ -83,20 +83,9 @@ namespace Jasper.Kafka.Internal
 
                 try
                 {
-                    await _callback.Received(Address, new[] {envelope}).ContinueWith(t =>
-                    {
-                        try
-                        {
-                            _consumer.Commit();
-                        }
-                        catch (KafkaException ke)
-                        {
-                            if (ke.Error?.Code != ErrorCode.Local_NoOffset)
-                            {
-                                throw;
-                            }
-                        }
-                    });
+                    await _callback.Received(Address, new[] {envelope});
+                    
+                    _consumer.Commit(message);
                 }
                 catch (Exception e)
                 {

--- a/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaSender.cs
+++ b/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaSender.cs
@@ -44,9 +44,7 @@ namespace Jasper.ConfluentKafka.Internal
             Envelope envelope = Envelope.ForPing(Destination);
             try
             {
-                Message<byte[], byte[]> message = _protocol.WriteFromEnvelope(envelope);
-
-                await _publisher.ProduceAsync("jasper-ping", message, cancellationToken);
+                await Send(envelope);
             }
             catch
             {

--- a/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaSender.cs
+++ b/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaSender.cs
@@ -45,7 +45,7 @@ namespace Jasper.ConfluentKafka.Internal
             _callback = callback;
         }
 
-        public Task Enqueue(Envelope envelope)
+        public Task Send(Envelope envelope)
         {
             _sending.Post(envelope);
 

--- a/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaSender.cs
+++ b/src/Jasper.ConfluentKafka/Internal/ConfluentKafkaSender.cs
@@ -1,11 +1,8 @@
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 using Confluent.Kafka;
 using Jasper.ConfluentKafka.Exceptions;
-using Jasper.Logging;
 using Jasper.Transports;
 using Jasper.Transports.Sending;
 
@@ -13,21 +10,15 @@ namespace Jasper.ConfluentKafka.Internal
 {
     public class ConfluentKafkaSender : ISender
     {
-        private ITransportProtocol<Message<byte[], byte[]>> _protocol;
-        private IProducer<byte[], byte[]> _publisher;
+        private readonly ITransportProtocol<Message<byte[], byte[]>> _protocol;
+        private readonly IProducer<byte[], byte[]> _publisher;
         private readonly KafkaEndpoint _endpoint;
-        private readonly ITransportLogger _logger;
-        private readonly CancellationToken _cancellation;
-        private ActionBlock<Envelope> _sending;
-        private ISenderCallback _callback;
-
-        public ConfluentKafkaSender(KafkaEndpoint endpoint, ITransportLogger logger, CancellationToken cancellation)
+        public bool SupportsNativeScheduledSend { get; } = false;
+        public Uri Destination => _endpoint.Uri;
+        public ConfluentKafkaSender(KafkaEndpoint endpoint)
         {
             _endpoint = endpoint;
-            _logger = logger;
-            _cancellation = cancellation;
             _publisher = new ProducerBuilder<byte[], byte[]>(endpoint.ProducerConfig).Build();
-            _sending = new ActionBlock<Envelope>(sendBySession, _endpoint.ExecutionOptions);
             _protocol = new KafkaTransportProtocol();
         }
 
@@ -36,84 +27,40 @@ namespace Jasper.ConfluentKafka.Internal
             _publisher?.Dispose();
         }
 
-        public Uri Destination => _endpoint.Uri;
-        public int QueuedCount => _sending.InputCount;
-        public bool Latched { get; private set; }
-
-        public void Start(ISenderCallback callback)
-        {
-            _callback = callback;
-        }
-
-        public Task Send(Envelope envelope)
-        {
-            _sending.Post(envelope);
-
-            return Task.CompletedTask;
-        }
-
-        public Task LatchAndDrain()
-        {
-            Latched = true;
-
-            _publisher.Flush(_cancellation);
-
-            _sending.Complete();
-
-            _logger.CircuitBroken(Destination);
-
-            return Task.CompletedTask;
-        }
-
-        public void Unlatch()
-        {
-            _logger.CircuitResumed(Destination);
-
-            Start(_callback);
-            Latched = false;
-        }
-
         public async Task<bool> Ping(CancellationToken cancellationToken)
         {
             Envelope envelope = Envelope.ForPing(Destination);
-            Message<byte[], byte[]> message = _protocol.WriteFromEnvelope(envelope);
+            try
+            {
+                Message<byte[], byte[]> message = _protocol.WriteFromEnvelope(envelope);
 
-            message.Headers.Add("MessageGroupId", Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()));
-            message.Headers.Add("Jasper_SessionId", Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()));
-
-            await _publisher.ProduceAsync("jasper-ping", message, cancellationToken);
+                await _publisher.ProduceAsync("jasper-ping", message, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
 
             return true;
         }
 
-        public bool SupportsNativeScheduledSend { get; } = false;
-
-        private async Task sendBySession(Envelope envelope)
+        public async Task Send(Envelope envelope)
         {
+            if (envelope.IsDelayed(DateTime.UtcNow))
+            {
+                throw new UnsupportedFeatureException("Delayed Message Delivery");
+            }
+
+            Message<byte[], byte[]> message = _protocol.WriteFromEnvelope(envelope);
             try
             {
-                Message<byte[], byte[]> message = _protocol.WriteFromEnvelope(envelope);
-                message.Headers.Add("Jasper_SessionId", Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()));
-
-                if (envelope.IsDelayed(DateTime.UtcNow))
-                {
-                    throw new UnsupportedFeatureException("Delayed Message Delivery");
-                }
-
-                await _publisher.ProduceAsync(_endpoint.TopicName, message, _cancellation);
-
-                await _callback.Successful(envelope);
+                var result = await _publisher.ProduceAsync(_endpoint.TopicName, message);
+                Console.WriteLine(result.Status);
             }
             catch (Exception e)
             {
-                try
-                {
-                    await _callback.ProcessingFailure(envelope, e);
-                }
-                catch (Exception exception)
-                {
-                    _logger.LogException(exception);
-                }
+                Console.WriteLine(e);
+                throw;
             }
         }
     }

--- a/src/Jasper.ConfluentKafka/Jasper.ConfluentKafka.csproj
+++ b/src/Jasper.ConfluentKafka/Jasper.ConfluentKafka.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.4.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jasper.ConfluentKafka/Jasper.ConfluentKafka.csproj
+++ b/src/Jasper.ConfluentKafka/Jasper.ConfluentKafka.csproj
@@ -1,8 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Kafka Transport for Jasper Messaging Systems using Confluent Kafka Client</Description>
+    <Authors>Jeremy D. Miller, Jarrod Johnson</Authors>
     <TargetFramework>netstandard2.1</TargetFramework>
     <DebugType>portable</DebugType>
+    <AssemblyName>Jasper.ConfluentKafka</AssemblyName>
+    <PackageId>Jasper.ConfluentKafka</PackageId>
+    <PackageIconUrl>https://avatars2.githubusercontent.com/u/10048186?v=3&amp;s=200</PackageIconUrl>
+    <PackageProjectUrl>http://jasperfx.github.io</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/JasperFX/jasper/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +24,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Jasper\Jasper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/src/Jasper.ConfluentKafka/KafkaEndpoint.cs
+++ b/src/Jasper.ConfluentKafka/KafkaEndpoint.cs
@@ -17,8 +17,8 @@ namespace Jasper.ConfluentKafka
     {
         private const string TopicToken = "topic";
         public string TopicName { get; set; }
-        public ProducerConfig ProducerConfig { get; set; } = new ProducerConfig();
-        public ConsumerConfig ConsumerConfig { get; set; } = new ConsumerConfig();
+        public ProducerConfig ProducerConfig { get; set; }
+        public ConsumerConfig ConsumerConfig { get; set; }
         public override Uri Uri => BuildUri();
 
         public KafkaEndpoint()

--- a/src/Jasper.ConfluentKafka/KafkaEndpoint.cs
+++ b/src/Jasper.ConfluentKafka/KafkaEndpoint.cs
@@ -17,9 +17,20 @@ namespace Jasper.ConfluentKafka
     {
         private const string TopicToken = "topic";
         public string TopicName { get; set; }
-        public ProducerConfig ProducerConfig { get; set; }
-        public ConsumerConfig ConsumerConfig { get; set; }
+        public ProducerConfig ProducerConfig { get; set; } = new ProducerConfig();
+        public ConsumerConfig ConsumerConfig { get; set; } = new ConsumerConfig();
         public override Uri Uri => BuildUri();
+
+        public KafkaEndpoint()
+        {
+            
+        }
+        public KafkaEndpoint(Uri uri) : base(uri)
+        {
+
+        }
+
+
         private Uri BuildUri(bool forReply = false)
         {
             var list = new List<string>();
@@ -84,7 +95,7 @@ namespace Jasper.ConfluentKafka
 
         protected override ISender CreateSender(IMessagingRoot root)
         {
-            return new ConfluentKafkaSender(this, root.TransportLogger, root.Cancellation);
+            return new ConfluentKafkaSender(this);
         }
 
         public override Uri ReplyUri() => BuildUri(true);

--- a/src/Jasper.ConfluentKafka/KafkaTransport.cs
+++ b/src/Jasper.ConfluentKafka/KafkaTransport.cs
@@ -24,7 +24,15 @@ namespace Jasper.ConfluentKafka
 
         protected override IEnumerable<KafkaEndpoint> endpoints() => _endpoints.Values;
 
-        protected override KafkaEndpoint findEndpointByUri(Uri uri) => _endpoints[uri];
+        protected override KafkaEndpoint findEndpointByUri(Uri uri)
+        {
+            if (!_endpoints.ContainsKey(uri))
+            {
+                _endpoints.Add(uri, new KafkaEndpoint(uri));
+            }
+
+            return _endpoints[uri];
+        }
 
         public KafkaEndpoint EndpointForTopic(string topicName, ProducerConfig producerConifg) =>
             AddOrUpdateEndpoint(topicName, endpoint => endpoint.ProducerConfig = producerConifg);

--- a/src/Jasper.RabbitMQ/Internal/RabbitMqConnectionAgent.cs
+++ b/src/Jasper.RabbitMQ/Internal/RabbitMqConnectionAgent.cs
@@ -21,7 +21,7 @@ namespace Jasper.RabbitMQ.Internal
             teardownConnection();
         }
 
-        internal void Connect()
+        internal void EnsureConnected()
         {
             lock (_locker)
             {

--- a/src/Jasper.RabbitMQ/Internal/RabbitMqEndpoint.cs
+++ b/src/Jasper.RabbitMQ/Internal/RabbitMqEndpoint.cs
@@ -2,13 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Baseline;
-using ImTools;
 using Jasper.Configuration;
 using Jasper.Runtime;
 using Jasper.Transports;
 using Jasper.Transports.Sending;
 using Jasper.Util;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Jasper.RabbitMQ.Internal
 {
@@ -127,10 +125,8 @@ namespace Jasper.RabbitMQ.Internal
 
         protected override ISender CreateSender(IMessagingRoot root)
         {
-            return new RabbitMqSender(root.TransportLogger, this, Parent, root.Cancellation);
+            return new RabbitMqSender(this, this.Parent);
         }
-
-
     }
 
 

--- a/src/Jasper.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Jasper.RabbitMQ/Internal/RabbitMqListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Baseline;
 using Jasper.Logging;
 using Jasper.Transports;
@@ -48,7 +48,7 @@ namespace Jasper.RabbitMQ.Internal
         {
             if (callback == null) return;
 
-            Connect();
+            EnsureConnected();
 
             _callback = callback;
             _consumer = new MessageConsumer(callback, _logger, Channel, _mapper, Address)

--- a/src/Jasper.RabbitMQ/Internal/RabbitMqSender.cs
+++ b/src/Jasper.RabbitMQ/Internal/RabbitMqSender.cs
@@ -47,7 +47,7 @@ namespace Jasper.RabbitMQ.Internal
             });
         }
 
-        public Task Enqueue(Envelope envelope)
+        public Task Send(Envelope envelope)
         {
             _sending.Post(envelope);
 

--- a/src/Jasper.Testing/Runtime/ping_handling.cs
+++ b/src/Jasper.Testing/Runtime/ping_handling.cs
@@ -20,7 +20,7 @@ namespace Jasper.Testing.Runtime
                 var sender = new BatchedSender("tcp://localhost:2222".ToUri(), new SocketSenderProtocol(),
                     CancellationToken.None, TransportLogger.Empty());
 
-                sender.Start(new StubSenderCallback());
+                sender.RegisterCallback(new StubSenderCallback());
 
                 await sender.Ping(CancellationToken.None);
             }

--- a/src/Jasper.Testing/Transports/Sending/BatchedSenderTests.cs
+++ b/src/Jasper.Testing/Transports/Sending/BatchedSenderTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
 using Jasper.Logging;
@@ -16,7 +16,8 @@ namespace Jasper.Testing.Transports.Sending
         {
             theSender = new BatchedSender(TransportConstants.RepliesUri, theProtocol, theCancellation.Token,
                 TransportLogger.Empty());
-            theSender.Start(theSenderCallback);
+
+            theSender.RegisterCallback(theSenderCallback);
 
             theBatch = new OutgoingMessageBatch(theSender.Destination, new[]
             {

--- a/src/Jasper.Testing/Transports/Sending/NulloSenderTester.cs
+++ b/src/Jasper.Testing/Transports/Sending/NulloSenderTester.cs
@@ -19,7 +19,7 @@ namespace Jasper.Testing.Transports.Sending
 
             var env = ObjectMother.Envelope();
 
-            await sender.Enqueue(env);
+            await sender.Send(env);
 
             callback.Received().Successful(env);
         }

--- a/src/Jasper.Testing/Transports/Sending/NulloSenderTester.cs
+++ b/src/Jasper.Testing/Transports/Sending/NulloSenderTester.cs
@@ -1,8 +1,8 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Jasper.Testing.Messaging;
 using Jasper.Transports.Sending;
 using Jasper.Util;
-using NSubstitute;
 using Xunit;
 
 namespace Jasper.Testing.Transports.Sending
@@ -14,14 +14,9 @@ namespace Jasper.Testing.Transports.Sending
         {
             var sender = new NulloSender("tcp://localhost:3333".ToUri());
 
-            var callback = Substitute.For<ISenderCallback>();
-            sender.Start(callback);
-
             var env = ObjectMother.Envelope();
 
             await sender.Send(env);
-
-            callback.Received().Successful(env);
         }
     }
 }

--- a/src/Jasper.Testing/Transports/Tcp/LightweightTcpTransportCompliance.cs
+++ b/src/Jasper.Testing/Transports/Tcp/LightweightTcpTransportCompliance.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using Jasper.Util;
 using TestingSupport.Compliance;
 using Xunit;
@@ -6,28 +12,54 @@ namespace Jasper.Testing.Transports.Tcp
 {
     public class Sender : JasperOptions
     {
-        public Sender()
+        public Sender(int portNumber)
         {
-            Endpoints.ListenForMessagesFrom($"tcp://localhost:2289/incoming".ToUri());
+            Endpoints.ListenForMessagesFrom($"tcp://localhost:{portNumber}/incoming".ToUri());
+        }
+
+        public Sender()
+            : this(2389)
+        {
+
         }
     }
 
     public class Receiver : JasperOptions
     {
-        public Receiver()
+        public Receiver(int portNumber)
         {
-            Endpoints.ListenForMessagesFrom($"tcp://localhost:2288/incoming".ToUri());
+            Endpoints.ListenForMessagesFrom($"tcp://localhost:{portNumber}/incoming".ToUri());
+        }
+
+        public Receiver() : this(2388)
+        {
+
         }
     }
+
+
+    public class PortFinder
+    {
+        private static readonly IPEndPoint DefaultLoopbackEndpoint = new IPEndPoint(IPAddress.Loopback, port: 0);
+
+        public static int GetAvailablePort()
+        {
+            using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket.Bind(DefaultLoopbackEndpoint);
+            var port = ((IPEndPoint)socket.LocalEndPoint).Port;
+            return port;
+        }
+    }
+
 
     [Collection("compliance")]
     public class LightweightTcpTransportCompliance : SendingCompliance
     {
-        public LightweightTcpTransportCompliance() : base($"tcp://localhost:2288/incoming".ToUri())
+        public LightweightTcpTransportCompliance() : base($"tcp://localhost:{PortFinder.GetAvailablePort()}/incoming".ToUri())
         {
-            SenderIs<Sender>();
+            SenderIs(new Sender(PortFinder.GetAvailablePort()));
 
-            ReceiverIs<Receiver>();
+            ReceiverIs(new Receiver(theOutboundAddress.Port));
         }
     }
 }

--- a/src/Jasper.Testing/Transports/Tcp/Protocol/ProtocolContext.cs
+++ b/src/Jasper.Testing/Transports/Tcp/Protocol/ProtocolContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -21,7 +21,7 @@ namespace Jasper.Testing.Transports.Tcp.Protocol
         private readonly IPAddress theAddress = IPAddress.Loopback;
         private readonly int thePort = ++NextPort;
         private readonly ListeningAgent _listener;
-        private readonly Uri destination;
+        public readonly Uri Destination;
         private readonly OutgoingMessageBatch theMessageBatch;
 
 
@@ -30,7 +30,7 @@ namespace Jasper.Testing.Transports.Tcp.Protocol
 
         public ProtocolContext()
         {
-            destination = $"durable://localhost:{thePort}/incoming".ToUri();
+            Destination = $"durable://localhost:{thePort}/incoming".ToUri();
             _listener = new ListeningAgent(theReceiver, theAddress, thePort, "durable", CancellationToken.None);
 
 
@@ -44,7 +44,7 @@ namespace Jasper.Testing.Transports.Tcp.Protocol
                 outgoingMessage()
             };
 
-            theMessageBatch = new OutgoingMessageBatch(destination, messages);
+            theMessageBatch = new OutgoingMessageBatch(Destination, messages);
         }
 
         public void Dispose()
@@ -57,8 +57,8 @@ namespace Jasper.Testing.Transports.Tcp.Protocol
         {
             return new Envelope
             {
-                Destination = destination,
-                Data = new byte[] {1, 2, 3, 4, 5, 6, 7},
+                Destination = Destination,
+                Data = new byte[] { 1, 2, 3, 4, 5, 6, 7 },
                 SentAt = DateTime.Today.ToUniversalTime()
             };
         }
@@ -69,10 +69,10 @@ namespace Jasper.Testing.Transports.Tcp.Protocol
 
             using (var client = new TcpClient())
             {
-                if (Dns.GetHostName() == destination.Host)
-                    await client.ConnectAsync(IPAddress.Loopback, destination.Port);
+                if (Dns.GetHostName() == Destination.Host)
+                    await client.ConnectAsync(IPAddress.Loopback, Destination.Port);
 
-                await client.ConnectAsync(destination.Host, destination.Port);
+                await client.ConnectAsync(Destination.Host, Destination.Port);
 
                 await WireProtocol.Send(client.GetStream(), theMessageBatch, null, theSender);
             }

--- a/src/Jasper/Envelope.Internals.cs
+++ b/src/Jasper/Envelope.Internals.cs
@@ -136,7 +136,7 @@ namespace Jasper
             _enqueued = true;
 
 
-            return Sender.StoreAndForward(this);
+            return Sender.Forward(this);
         }
 
         internal Task QuickSend()

--- a/src/Jasper/Persistence/Durability/DurableSendingAgent.cs
+++ b/src/Jasper/Persistence/Durability/DurableSendingAgent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -77,7 +77,7 @@ namespace Jasper.Persistence.Durability
 
             foreach (var envelope in toRetry)
             {
-                await _sender.Enqueue(envelope);
+                await _sender.Send(envelope);
             }
         }
 
@@ -97,7 +97,7 @@ namespace Jasper.Persistence.Durability
         {
             await _persistence.StoreOutgoing(envelope, _settings.UniqueNodeId);
 
-            await _sender.Enqueue(envelope);
+            await _sender.Send(envelope);
         }
 
     }

--- a/src/Jasper/Persistence/Durability/DurableSendingAgent.cs
+++ b/src/Jasper/Persistence/Durability/DurableSendingAgent.cs
@@ -80,7 +80,6 @@ namespace Jasper.Persistence.Durability
                 await _sender.Send(envelope);
             }
         }
-
         public override Task Successful(OutgoingMessageBatch outgoing)
         {
             return _policy.ExecuteAsync(c => _persistence.DeleteOutgoing(outgoing.Messages.ToArray()), _settings.Cancellation);

--- a/src/Jasper/Tracking/JasperHostMessageTrackingExtensions.cs
+++ b/src/Jasper/Tracking/JasperHostMessageTrackingExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Baseline.Dates;
 using Jasper.Logging;
@@ -30,6 +30,13 @@ namespace Jasper.Tracking
         public static TrackedSessionConfiguration TrackActivity(this IHost host)
         {
             var session = new TrackedSession(host);
+            return new TrackedSessionConfiguration(session);
+        }
+
+        public static TrackedSessionConfiguration TrackActivity(this IHost host, TimeSpan trackingTimeout)
+        {
+            var session = new TrackedSession(host);
+            session.Timeout = trackingTimeout;
             return new TrackedSessionConfiguration(session);
         }
 

--- a/src/Jasper/Tracking/TrackedSession.cs
+++ b/src/Jasper/Tracking/TrackedSession.cs
@@ -45,6 +45,7 @@ namespace Jasper.Tracking
         public TimeSpan Timeout { get; set; } = 5.Seconds();
 
         public bool AssertNoExceptions { get; set; } = true;
+        public bool AssertNoTimeout { get; set; } = true;
 
         public Func<IMessageContext, Task> Execution { get; set; } = c => Task.CompletedTask;
 
@@ -166,9 +167,6 @@ namespace Jasper.Tracking
 
             _stopwatch.Start();
 
-
-
-
             try
             {
                 using (var scope = _primaryHost.Services.As<IContainer>().GetNestedContainer())
@@ -191,7 +189,7 @@ namespace Jasper.Tracking
 
             if (AssertNoExceptions) AssertNoExceptionsWereThrown();
 
-            AssertNotTimedOut();
+            if (AssertNoExceptions) AssertNotTimedOut();
         }
 
         public Task Track()

--- a/src/Jasper/Tracking/TrackedSession.cs
+++ b/src/Jasper/Tracking/TrackedSession.cs
@@ -262,12 +262,23 @@ namespace Jasper.Tracking
 
         public void LogException(Exception exception, string serviceName)
         {
+            Debug.WriteLine($"Exception Occurred in {serviceName}: {exception}");
             _exceptions.Add(exception);
         }
 
         public void AddCondition(ITrackedCondition condition)
         {
+            Debug.WriteLine($"Condition Added: {condition}");
             _conditions.Add(condition);
+        }
+
+        public override string ToString()
+        {
+            var conditionas = $"Conditions:\n{ _conditions.Select(x => x.ToString()).Join("\n")}";
+            var activity = $"Activity:\n{ AllRecordsInOrder().Select(x => x.ToString()).Join("\n")}";
+            var exceptions = $"Exceptions:\n{ _exceptions.Select(x => x.ToString()).Join("\n")}";
+
+            return $"{conditionas}\n\n{activity}\\{exceptions}";
         }
     }
 }

--- a/src/Jasper/Tracking/TrackedSessionConfiguration.cs
+++ b/src/Jasper/Tracking/TrackedSessionConfiguration.cs
@@ -68,6 +68,12 @@ namespace Jasper.Tracking
             return this;
         }
 
+        public TrackedSessionConfiguration DoNotAssertTimeout()
+        {
+            _session.AssertNoTimeout = false;
+            return this;
+        }
+
         public TrackedSessionConfiguration WaitForMessageToBeReceivedAt<T>(IHost host)
         {
             var condition = new WaitForMessage<T>
@@ -87,6 +93,13 @@ namespace Jasper.Tracking
         /// <param name="action"></param>
         /// <returns></returns>
         public async Task<ITrackedSession> ExecuteAndWait(Func<IMessageContext, Task> action)
+        {
+            _session.Execution = action;
+            await _session.ExecuteAndTrack();
+            return _session;
+        }
+
+        public async Task<ITrackedSession> ExecuteWithoutWaiting(Func<IMessageContext, Task> action)
         {
             _session.Execution = action;
             await _session.ExecuteAndTrack();

--- a/src/Jasper/Transports/Local/DurableLocalSendingAgent.cs
+++ b/src/Jasper/Transports/Local/DurableLocalSendingAgent.cs
@@ -52,7 +52,7 @@ namespace Jasper.Transports.Local
             return Enqueue(envelope);
         }
 
-        public async Task StoreAndForward(Envelope envelope)
+        public async Task Forward(Envelope envelope)
         {
             _messageLogger.Sent(envelope);
             writeMessageData(envelope);

--- a/src/Jasper/Transports/Local/LightweightLocalSendingAgent.cs
+++ b/src/Jasper/Transports/Local/LightweightLocalSendingAgent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Jasper.Configuration;
 using Jasper.Logging;
@@ -41,7 +41,7 @@ namespace Jasper.Transports.Local
                 : Enqueue(envelope);
         }
 
-        public Task StoreAndForward(Envelope envelope)
+        public Task Forward(Envelope envelope)
         {
             return EnqueueOutgoing(envelope);
         }

--- a/src/Jasper/Transports/Sending/BatchedSender.cs
+++ b/src/Jasper/Transports/Sending/BatchedSender.cs
@@ -5,11 +5,10 @@ using System.Threading.Tasks.Dataflow;
 using Jasper.Logging;
 using Jasper.Transports.Tcp;
 using Jasper.Transports.Util;
-using LamarCodeGeneration.Frames;
 
 namespace Jasper.Transports.Sending
 {
-    public class BatchedSender : ISender
+    public class BatchedSender : ISender, ISenderRequiresCallback
     {
         private readonly CancellationToken _cancellation;
         private readonly ITransportLogger _logger;
@@ -22,20 +21,12 @@ namespace Jasper.Transports.Sending
         private ActionBlock<OutgoingMessageBatch> _sender;
         private ActionBlock<Envelope> _serializing;
 
-        public BatchedSender(Uri destination, ISenderProtocol protocol, CancellationToken cancellation,
-            ITransportLogger logger)
+        public BatchedSender(Uri destination, ISenderProtocol protocol, CancellationToken cancellation, ITransportLogger logger)
         {
             Destination = destination;
             _protocol = protocol;
             _cancellation = cancellation;
             _logger = logger;
-        }
-
-        public Uri Destination { get; }
-
-        public void Start(ISenderCallback callback)
-        {
-            _callback = callback;
 
             _sender = new ActionBlock<OutgoingMessageBatch>(SendBatch, new ExecutionDataflowBlockOptions
             {
@@ -50,16 +41,16 @@ namespace Jasper.Transports.Sending
             }, _cancellation);
 
             _serializing = new ActionBlock<Envelope>(async e =>
+            {
+                try
                 {
-                    try
-                    {
-                        await _batching.SendAsync(e);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogException(ex, message: $"Error while trying to serialize envelope {e}");
-                    }
-                },
+                    await _batching.SendAsync(e);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogException(ex, message: $"Error while trying to serialize envelope {e}");
+                }
+            },
                 new ExecutionDataflowBlockOptions
                 {
                     CancellationToken = _cancellation,
@@ -81,7 +72,7 @@ namespace Jasper.Transports.Sending
                     return batch;
                 },
                 new ExecutionDataflowBlockOptions
-                    {BoundedCapacity = DataflowBlockOptions.Unbounded, MaxDegreeOfParallelism = 10, CancellationToken = _cancellation});
+                { BoundedCapacity = DataflowBlockOptions.Unbounded, MaxDegreeOfParallelism = 10, CancellationToken = _cancellation });
 
             _batchWriting.Completion.ContinueWith(x =>
             {
@@ -96,6 +87,8 @@ namespace Jasper.Transports.Sending
                 if (x.IsFaulted) _logger.LogException(x.Exception);
             }, _cancellation);
         }
+
+        public Uri Destination { get; }
 
         public int QueuedCount => _queued + _batching.ItemCount + _serializing.InputCount;
 
@@ -119,7 +112,6 @@ namespace Jasper.Transports.Sending
         {
             _logger.CircuitResumed(Destination);
 
-            Start(_callback);
             Latched = false;
         }
 
@@ -149,6 +141,8 @@ namespace Jasper.Transports.Sending
             _sender?.Complete();
             _batching?.Dispose();
         }
+
+        public void RegisterCallback(ISenderCallback senderCallback) => _callback = senderCallback;
 
         public async Task SendBatch(OutgoingMessageBatch batch)
         {

--- a/src/Jasper/Transports/Sending/BatchedSender.cs
+++ b/src/Jasper/Transports/Sending/BatchedSender.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
@@ -133,7 +133,7 @@ namespace Jasper.Transports.Sending
 
         public bool SupportsNativeScheduledSend { get; } = true;
 
-        public Task Enqueue(Envelope message)
+        public Task Send(Envelope message)
         {
             if (_batching == null) throw new InvalidOperationException("This agent has not been started");
 

--- a/src/Jasper/Transports/Sending/ISender.cs
+++ b/src/Jasper/Transports/Sending/ISender.cs
@@ -1,12 +1,19 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Jasper.Transports.Sending
 {
+    public interface ISenderRequiresCallback : IDisposable
+    {
+        void RegisterCallback(ISenderCallback senderCallback);
+    }
+
     public interface ISender : IDisposable
     {
+        bool SupportsNativeScheduledSend { get; }
         Uri Destination { get; }
-        
+        Task<bool> Ping(CancellationToken cancellationToken);
         Task Send(Envelope envelope);
     }
 }

--- a/src/Jasper/Transports/Sending/ISender.cs
+++ b/src/Jasper/Transports/Sending/ISender.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+using System;
 using System.Threading.Tasks;
 
 namespace Jasper.Transports.Sending
@@ -7,26 +6,7 @@ namespace Jasper.Transports.Sending
     public interface ISender : IDisposable
     {
         Uri Destination { get; }
-
-        int QueuedCount { get; }
-
-        bool Latched { get; }
-        void Start(ISenderCallback callback);
-
-        Task Enqueue(Envelope envelope);
-
-        Task LatchAndDrain();
-        void Unlatch();
-
-        /// <summary>
-        ///     Simply try to reach the endpoint to verify it can receive
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<bool> Ping(CancellationToken cancellationToken);
-
-        bool SupportsNativeScheduledSend { get; }
-
-
+        
+        Task Send(Envelope envelope);
     }
 }

--- a/src/Jasper/Transports/Sending/ISendingAgent.cs
+++ b/src/Jasper/Transports/Sending/ISendingAgent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Jasper.Configuration;
 
@@ -15,15 +15,13 @@ namespace Jasper.Transports.Sending
 
         bool SupportsNativeScheduledSend { get; }
 
-
-
         // This would be called in the future by the outbox, assuming
         // that the envelope is already persisted and just needs to be sent out
         Task EnqueueOutgoing(Envelope envelope);
 
         // This would be called by the EnvelopeSender if invoked
         // indirectly
-        Task StoreAndForward(Envelope envelope);
+        Task Forward(Envelope envelope);
 
         Endpoint Endpoint { get; }
 

--- a/src/Jasper/Transports/Sending/LightweightSendingAgent.cs
+++ b/src/Jasper/Transports/Sending/LightweightSendingAgent.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Baseline;
@@ -39,7 +39,7 @@ namespace Jasper.Transports.Sending
             foreach (var envelope in toRetry)
             {
                 // It's perfectly okay to not wait on the task here
-                _sender.Enqueue(envelope);
+                _sender.Send(envelope);
             }
 
             return Task.CompletedTask;
@@ -57,7 +57,7 @@ namespace Jasper.Transports.Sending
 
         protected override Task storeAndForward(Envelope envelope)
         {
-            return _sender.Enqueue(envelope);
+            return _sender.Send(envelope);
         }
 
         public override bool IsDurable { get; } = false;

--- a/src/Jasper/Transports/Sending/NulloSender.cs
+++ b/src/Jasper/Transports/Sending/NulloSender.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using LamarCodeGeneration.Frames;
 
 namespace Jasper.Transports.Sending
 {
-    public class NulloSender : ISender
+    public class NulloSender : ISender  
     {
-        private ISenderCallback _callback;
-
         public NulloSender(Uri destination)
         {
             Destination = destination;
@@ -18,35 +15,9 @@ namespace Jasper.Transports.Sending
         {
         }
 
-        public Uri Destination { get; }
-        public int QueuedCount => 0;
-        public bool Latched => false;
-        public void Start(ISenderCallback callback)
-        {
-            _callback = callback;
-        }
-
-        public Task Send(Envelope envelope)
-        {
-            _callback.Successful(envelope);
-            return Task.CompletedTask;
-        }
-
-        public Task LatchAndDrain()
-        {
-            return Task.CompletedTask;
-        }
-
-        public void Unlatch()
-        {
-
-        }
-
-        public Task<bool> Ping(CancellationToken cancellationToken)
-        {
-            return Task.FromResult(true);
-        }
-
         public bool SupportsNativeScheduledSend { get; } = false;
+        public Uri Destination { get; }
+        public Task Send(Envelope envelope) => Task.CompletedTask;
+        public Task<bool> Ping(CancellationToken cancellationToken) => Task.FromResult(true);
     }
 }

--- a/src/Jasper/Transports/Sending/NulloSender.cs
+++ b/src/Jasper/Transports/Sending/NulloSender.cs
@@ -26,7 +26,7 @@ namespace Jasper.Transports.Sending
             _callback = callback;
         }
 
-        public Task Enqueue(Envelope envelope)
+        public Task Send(Envelope envelope)
         {
             _callback.Successful(envelope);
             return Task.CompletedTask;

--- a/src/Jasper/Transports/Sending/SendingAgent.cs
+++ b/src/Jasper/Transports/Sending/SendingAgent.cs
@@ -62,7 +62,7 @@ namespace Jasper.Transports.Sending
            _messageLogger.Sent(envelope);
         }
 
-        public async Task StoreAndForward(Envelope envelope)
+        public async Task Forward(Envelope envelope)
         {
             setDefaults(envelope);
 

--- a/src/Jasper/Transports/Sending/SendingAgent.cs
+++ b/src/Jasper/Transports/Sending/SendingAgent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,7 +52,7 @@ namespace Jasper.Transports.Sending
         public async Task EnqueueOutgoing(Envelope envelope)
         {
             setDefaults(envelope);
-            await _sender.Enqueue(envelope);
+            await _sender.Send(envelope);
             _messageLogger.Sent(envelope);
         }
 
@@ -94,7 +94,7 @@ namespace Jasper.Transports.Sending
                 foreach (var envelope in batch.Messages)
                 {
 #pragma warning disable 4014
-                    _sender.Enqueue(envelope);
+                    _sender.Send(envelope);
 #pragma warning restore 4014
                 }
             }

--- a/src/Jasper/Transports/Sending/SendingAgent.cs
+++ b/src/Jasper/Transports/Sending/SendingAgent.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using Baseline;
 using Jasper.Configuration;
 using Jasper.Logging;
@@ -18,14 +19,19 @@ namespace Jasper.Transports.Sending
         private int _failureCount;
         private CircuitWatcher _circuitWatcher;
 
-        public SendingAgent(ITransportLogger logger, IMessageLogger messageLogger, ISender sender,
-            AdvancedSettings settings, Endpoint endpoint)
+        public SendingAgent(ITransportLogger logger, IMessageLogger messageLogger, ISender sender, AdvancedSettings settings, Endpoint endpoint)
         {
             _logger = logger;
             _messageLogger = messageLogger;
             _sender = sender;
             _settings = settings;
             Endpoint = endpoint;
+            _sending = new ActionBlock<Envelope>(sendViaSender, Endpoint.ExecutionOptions);
+
+            _sending.Completion.ContinueWith(t =>
+            {
+                Console.WriteLine(t.Exception?.ToString());
+            });
         }
 
         public Endpoint Endpoint { get; }
@@ -39,7 +45,7 @@ namespace Jasper.Transports.Sending
             _sender.Dispose();
         }
 
-        public bool Latched => _sender.Latched;
+        public bool Latched { get; private set; }
         public abstract bool IsDurable { get; }
 
         private void setDefaults(Envelope envelope)
@@ -52,8 +58,8 @@ namespace Jasper.Transports.Sending
         public async Task EnqueueOutgoing(Envelope envelope)
         {
             setDefaults(envelope);
-            await _sender.Send(envelope);
-            _messageLogger.Sent(envelope);
+           _sending.Post(envelope);
+           _messageLogger.Sent(envelope);
         }
 
         public async Task StoreAndForward(Envelope envelope)
@@ -67,13 +73,69 @@ namespace Jasper.Transports.Sending
 
         protected abstract Task storeAndForward(Envelope envelope);
 
-        public bool SupportsNativeScheduledSend => _sender.SupportsNativeScheduledSend;
+        public Task<bool> TryToResume(CancellationToken cancellationToken)
+        {
+            return _sender.Ping(cancellationToken);
+        }
+        TimeSpan ICircuit.RetryInterval => Endpoint.PingIntervalForCircuitResume;
 
+        Task ICircuit.Resume(CancellationToken cancellationToken)
+        {
+            _circuitWatcher = null;
+
+            Unlatch();
+
+            return afterRestarting(_sender);
+        }
+
+        protected abstract Task afterRestarting(ISender sender);
+        
+        public abstract Task Successful(Envelope outgoing);
+
+        private ActionBlock<Envelope> _sending;
+        public Task LatchAndDrain()
+        {
+            Latched = true;
+
+            _sending.Complete();
+
+            _logger.CircuitBroken(Destination);
+
+            return Task.CompletedTask;
+        }
+
+        public void Unlatch()
+        {
+            _logger.CircuitResumed(Destination);
+
+            Latched = false;
+        }
+
+        private async Task sendViaSender(Envelope envelope)
+        {
+            try
+            {
+                await _sender.Send(envelope);
+
+                await Successful(envelope);
+            }
+            catch (Exception e)
+            {
+                try
+                {
+                    await ((ISenderCallback)this).ProcessingFailure(envelope, e);
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogException(exception);
+                }
+            }
+        }
 
         public async Task MarkFailed(OutgoingMessageBatch batch)
         {
             // If it's already latched, just enqueue again
-            if (_sender.Latched)
+            if (Latched)
             {
                 await EnqueueForRetry(batch);
                 return;
@@ -83,11 +145,10 @@ namespace Jasper.Transports.Sending
 
             if (_failureCount >= Endpoint.FailuresBeforeCircuitBreaks)
             {
-                await _sender.LatchAndDrain();
+                await LatchAndDrain();
                 await EnqueueForRetry(batch);
 
                 _circuitWatcher = new CircuitWatcher(this, _settings.Cancellation);
-                //_circuitWatcher = new CircuitWatcher(_sender, _endpoint.PingIntervalForCircuitResume, restartSending);
             }
             else
             {
@@ -100,34 +161,19 @@ namespace Jasper.Transports.Sending
             }
         }
 
-        public Task<bool> TryToResume(CancellationToken cancellationToken)
-        {
-            return _sender.Ping(cancellationToken);
-        }
-
-        TimeSpan ICircuit.RetryInterval => Endpoint.PingIntervalForCircuitResume;
 
         public abstract Task EnqueueForRetry(OutgoingMessageBatch batch);
 
-        Task ICircuit.Resume(CancellationToken cancellationToken)
-        {
-            _circuitWatcher = null;
-
-            _sender.Unlatch();
-
-            return afterRestarting(_sender);
-        }
-
-        protected abstract Task afterRestarting(ISender sender);
 
         public Task MarkSuccess()
         {
             _failureCount = 0;
-            _sender.Unlatch();
+            Unlatch();
             _circuitWatcher = null;
 
             return Task.CompletedTask;
         }
+        
 
         Task ISenderCallback.TimedOut(OutgoingMessageBatch outgoing)
         {
@@ -160,7 +206,7 @@ namespace Jasper.Transports.Sending
 
         Task ISenderCallback.ProcessingFailure(Envelope outgoing, Exception exception)
         {
-            var batch = new OutgoingMessageBatch(outgoing.Destination, new[] {outgoing});
+            var batch = new OutgoingMessageBatch(outgoing.Destination, new[] { outgoing });
             _logger.OutgoingBatchFailed(batch, exception);
             return MarkFailed(batch);
         }
@@ -180,8 +226,7 @@ namespace Jasper.Transports.Sending
 
         public abstract Task Successful(OutgoingMessageBatch outgoing);
 
-        public abstract Task Successful(Envelope outgoing);
-
+        public bool SupportsNativeScheduledSend => _sender.SupportsNativeScheduledSend;
 
     }
 }

--- a/src/Jasper/Transports/TransportBase.cs
+++ b/src/Jasper/Transports/TransportBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jasper.Configuration;
@@ -82,7 +82,9 @@ namespace Jasper.Transports
 
             var endpoint = findEndpointByUri(canonicizeUri(uri));
 
-            // It's coded this way so you don't override
+            if(endpoint == null)
+
+                // It's coded this way so you don't override
             // durability if it's already set
             if (shouldBeDurable) endpoint.IsDurable = true;
 

--- a/src/Jasper/Transports/TransportRuntime.cs
+++ b/src/Jasper/Transports/TransportRuntime.cs
@@ -67,9 +67,13 @@ namespace Jasper.Transports
                     : new LightweightSendingAgent(_root.TransportLogger, _root.MessageLogger, sender, _root.Settings, endpoint);
 
                 agent.ReplyUri = replyUri;
-                sender.Start((ISenderCallback) agent);
 
                 endpoint.Agent = agent;
+
+                if (sender is ISenderRequiresCallback senderRequiringCallback && agent is ISenderCallback callbackAgent)
+                {
+                    senderRequiringCallback.RegisterCallback(callbackAgent);
+                }
 
                 AddSendingAgent(agent);
                 AddSubscriber(endpoint);
@@ -156,10 +160,8 @@ namespace Jasper.Transports
                 ? (IWorkerQueue) new DurableWorkerQueue(settings, _root.Pipeline, _root.Settings, _root.Persistence,
                     _root.TransportLogger)
                 : new LightweightWorkerQueue(settings, _root.TransportLogger, _root.Pipeline, _root.Settings);
-
-
+            
             _listeners.Add(worker);
-
 
             worker.StartListening(listener);
         }

--- a/src/StorytellerSpecs/Fixtures/RetryAgentFixture.cs
+++ b/src/StorytellerSpecs/Fixtures/RetryAgentFixture.cs
@@ -38,10 +38,6 @@ namespace StorytellerSpecs.Fixtures
         {
         }
 
-        void ISender.Start(ISenderCallback callback)
-        {
-        }
-
         Task ISender.Send(Envelope envelope)
         {
             _enqueued.Add(envelope);
@@ -50,17 +46,15 @@ namespace StorytellerSpecs.Fixtures
 
         Uri ISender.Destination { get; }
 
-        int ISender.QueuedCount { get; }
+        bool Latched => _latched;
 
-        bool ISender.Latched => _latched;
-
-        Task ISender.LatchAndDrain()
+        Task LatchAndDrain()
         {
             _latched = true;
             return Task.CompletedTask;
         }
 
-        void ISender.Unlatch()
+        void Unlatch()
         {
             _unlatched = true;
         }

--- a/src/StorytellerSpecs/Fixtures/RetryAgentFixture.cs
+++ b/src/StorytellerSpecs/Fixtures/RetryAgentFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -42,7 +42,7 @@ namespace StorytellerSpecs.Fixtures
         {
         }
 
-        Task ISender.Enqueue(Envelope envelope)
+        Task ISender.Send(Envelope envelope)
         {
             _enqueued.Add(envelope);
             return Task.CompletedTask;

--- a/src/StorytellerSpecs/Stub/StubEndpoint.cs
+++ b/src/StorytellerSpecs/Stub/StubEndpoint.cs
@@ -17,7 +17,6 @@ namespace StorytellerSpecs.Stub
         public readonly IList<StubChannelCallback> Callbacks = new List<StubChannelCallback>();
 
         public readonly IList<Envelope> Sent = new List<Envelope>();
-        private ISenderCallback _callback;
         private IMessageLogger _logger;
         private IHandlerPipeline _pipeline;
         private Uri _replyUri;
@@ -31,43 +30,21 @@ namespace StorytellerSpecs.Stub
         }
 
         public Endpoint Endpoint => this;
+        public bool Latched { get; set; }
 
         public override Uri Uri => $"stub://{Name}".ToUri();
-
-        public int QueuedCount { get; }
-
-        public void Start(ISenderCallback callback)
-        {
-            _callback = callback;
-        }
-
+        
         public Task Send(Envelope envelope)
         {
             Sent.Add(envelope);
             return _pipeline?.Invoke(envelope, new StubChannelCallback(this, envelope)) ?? Task.CompletedTask;
         }
 
-        public Task LatchAndDrain()
-        {
-            return Task.CompletedTask;
-        }
-
-        public void Unlatch()
-        {
-            Latched = false;
-        }
-
-        public Task<bool> Ping(CancellationToken cancellationToken)
-        {
-            return Task.FromResult(true);
-        }
-
+        public Task<bool> Ping(CancellationToken cancellationToken) => Task.FromResult(true);
 
         public void Dispose()
         {
         }
-
-        public bool Latched { get; set; }
 
         public Uri Destination { get; }
 

--- a/src/StorytellerSpecs/Stub/StubEndpoint.cs
+++ b/src/StorytellerSpecs/Stub/StubEndpoint.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,7 +41,7 @@ namespace StorytellerSpecs.Stub
             _callback = callback;
         }
 
-        public Task Enqueue(Envelope envelope)
+        public Task Send(Envelope envelope)
         {
             Sent.Add(envelope);
             return _pipeline?.Invoke(envelope, new StubChannelCallback(this, envelope)) ?? Task.CompletedTask;

--- a/src/StorytellerSpecs/Stub/StubEndpoint.cs
+++ b/src/StorytellerSpecs/Stub/StubEndpoint.cs
@@ -77,7 +77,7 @@ namespace StorytellerSpecs.Stub
             return Task.CompletedTask;
         }
 
-        public Task StoreAndForward(Envelope envelope)
+        public Task Forward(Envelope envelope)
         {
             return EnqueueOutgoing(envelope);
         }


### PR DESCRIPTION
After adding the Kafka Transport it was noticed that there was a lot of similarities between all transports in that they all:

- implemented the same kind of localized queuing via an `ActionBlock`
- needed to make sure to call the right `ISenderCallback` methods at the right times

After discussing with @jeremydmiller we decided to pull this logic up into the `SendingAgent`. The benefits of this are:

- One less set of asynchronous behavior
- Should be much more straight-forward to add additional transports in the future
- Should pave the way for other delivery modes (for example, inline send for immediate feedback)

This PR is a result of this effort. 